### PR TITLE
Translated missing fields to Spanish

### DIFF
--- a/src/common/i18n/text_es.ts
+++ b/src/common/i18n/text_es.ts
@@ -6,7 +6,7 @@ export default {
     common_error_photoNotExisting: `Foto no encontrada`,
     common_error_photoNotExisting_desc: `Esta foto ya no se encuentra donde estaba ubicada en el último escaneo. Quizás fue movida, borrada o se encuentra en un disco que no está conectado`,
 
-    key_space: ``,  // TODO: 'Space'
+    key_space: 'Barra Espaciadora',  // TODO: 'Space'- Translated
 
     App_error_noWebGL_title: `WebGL deshabilitado`,
     App_error_noWebGL_desc: `Picturama necesita una tarjeta gráfica con aceleración 3D para poder funcionar. Por favor revisa en la configuración de tu sistema si es posible activar la aceleración 3D y reinicia Picturama.`,
@@ -73,7 +73,7 @@ export default {
     Library_noPhotos_message: 'Presiona {0} o el botón más abajo para empezar el escaneo de las fotos en las carpetas.',
     Library_startScanning: 'Comenzar el escaneo',
     Library_emptyTrash: 'La papelera está vacía',
-    Library_emptyFavorites: "No mascaste ninguna foto como favorita todavía",
+    Library_emptyFavorites: "No marcaste ninguna foto como favorita todavía",
     Library_emptyView: "No hay ninguna foto en tu vista actual",
     Library_selectOtherView: 'Por favor, selecciona otra vista en la parte superior a la izquierda.',
 
@@ -94,7 +94,7 @@ export default {
     MainMenu_quit: `Salir`,
     MainMenu_file: `Archivo`,
     MainMenu_export: `Exportar fotos`,
-    MainMenu_scan: `Scanear en busca de imágenes`,
+    MainMenu_scan: `Escanear en busca de imágenes`,
     MainMenu_view: `Ver`,
     MainMenu_toggleFullScreen: `Mostrar pantalla completa`,
     MainMenu_developer: `Desarrollador`,
@@ -102,9 +102,9 @@ export default {
     MainMenu_toggleUiTester: `Mostrar probador de UI`,
     MainMenu_reloadUi: `Recargar UI`,
 
-    Picture_showDetails: ``,  // TODO: 'View photo'
-    Picture_select: ``,  // TODO: 'Select'
-    Picture_deselect: ``,  // TODO: 'Deselect'
+    Picture_showDetails: 'Ver foto',  // TODO: 'View photo' -Transalted
+    Picture_select: 'Seleccionar',  // TODO: 'Select' -Transalted
+    Picture_deselect: 'Deseleccionar',  // TODO: 'Deselect' -Transalted
     Picture_error_createThumbnail: `Falló la creación de la miniatura`,
 
     PhotoActionButtons_movedToTrash_one: 'Mover foto a la papelera',
@@ -121,8 +121,8 @@ export default {
 
     PhotoDetailPane_prevPhoto: 'Anterior foto',
     PhotoDetailPane_nextPhoto: 'Siguiente foto',
-    PhotoDetailBody_selected: ``,  // TODO: 'Selected'
-    PhotoDetailBody_select: ``,  // TODO: 'Select'
+    PhotoDetailBody_selected: 'Seleccionado',  // TODO: 'Selected' - Translated
+    PhotoDetailBody_select: 'Escoger',  // TODO: 'Select' -Translated
     PhotoDetailPane_edit: 'Editar',
 
     PhotoInfo_title: 'Info',
@@ -146,7 +146,7 @@ export default {
     RotateButtonGroup_rotateRight: 'Rotar a la derecha',
 
     SelectionSummary_selected: '{0} selectionados',
-    SelectionSummary_clearSelection: ``,  // TODO: 'Clear selection'
+    SelectionSummary_clearSelection: 'Quitar Selección',  // TODO: 'Clear selection'-Translated
 
     Settings_title: 'Ajustes',
     Settings_selectPhotoDirs: 'Por favor, selecciona carpetas para escanear imágenes.',


### PR DESCRIPTION
To the following Fields:

key_space: 'Barra Espaciadora',  // TODO: 'Space'- Translated
Picture_showDetails: 'Ver foto',  // TODO: 'View photo' -Transalted
Picture_select: 'Seleccionar',  // TODO: 'Select' -Transalted
Picture_deselect: 'Deseleccionar',  // TODO: 'Deselect' -Transalted
PhotoDetailBody_selected: 'Seleccionado',  // TODO: 'Selected' - Translated
PhotoDetailBody_select: 'Escoger',  // TODO: 'Select' -Translated
 SelectionSummary_clearSelection: 'Quitar Selección',  // TODO: 'Clear selection'-Translated