### PR TITLE
feat: support del hotkey for deleting photos in detail view

### DIFF
--- a/src/app/ui/detail/PhotoDetailBody.tsx
+++ b/src/app/ui/detail/PhotoDetailBody.tsx
@@ -23,6 +23,7 @@ import ViewModeLayer from './ViewModeLayer'
 
 import './PhotoDetailBody.less'
 
+import {movePhotosToTrash} from 'app/util/PhotoUtil'
 
 export const cropModeInsets: Insets = { left: 60, right: 80, top: 60, bottom: 60 }
 
@@ -75,7 +76,7 @@ export default class PhotoDetailBody extends React.Component<Props, State> {
     constructor(props: Props) {
         super(props)
         bindMany(this, 'onLoadingStateChange', 'onResize', 'onTextureChange', 'onTogglePhotoSelected', 
-            'setPhotoPosition', 'enterCropMode', 'onPhotoWorkEdited', 'onCropDone')
+            'setPhotoPosition', 'enterCropMode', 'onPhotoWorkEdited', 'onCropDone', "moveToTrash")
         const cameraMetricsBuilder = new CameraMetricsBuilder()
         this.state = {
             prevMode: null,
@@ -200,6 +201,11 @@ export default class PhotoDetailBody extends React.Component<Props, State> {
         this.props.setMode('view')
     }
 
+    private moveToTrash() { 
+        const {props} = this
+        movePhotosToTrash(props.photo, props.photoActionController)
+    }
+
     render() {
         const { props, state } = this
         const isSelected = isPhotoSelected(props.sectionId, props.photo.id, props.selection)
@@ -256,6 +262,7 @@ export default class PhotoDetailBody extends React.Component<Props, State> {
                         togglePhotoSelected={this.onTogglePhotoSelected}
                         enterCropMode={this.enterCropMode}
                         closeDetail={props.closeDetail}
+                        movePhotosToTrash={this.moveToTrash}
                     />
                 }
                 {props.mode === 'crop' && props.photoWork && state.cameraMetrics &&

--- a/src/app/ui/detail/ViewModeLayer.tsx
+++ b/src/app/ui/detail/ViewModeLayer.tsx
@@ -30,9 +30,10 @@ export interface Props {
     togglePhotoSelected(): void
     enterCropMode(): void
     closeDetail(): void
+    movePhotosToTrash(): void
 }
 
-type CommandKeys = 'close' | 'prevPhoto' | 'nextPhoto' | 'toggleSelected' | 'edit'
+type CommandKeys = 'close' | 'prevPhoto' | 'nextPhoto' | 'toggleSelected' | 'edit' | 'delete'
 
 export default class ViewModeLayer extends React.Component<Props> {
 
@@ -49,6 +50,7 @@ export default class ViewModeLayer extends React.Component<Props> {
             nextPhoto: { combo: 'right', enabled: () => !this.props.isLast, label: msg('PhotoDetailPane_nextPhoto'), onAction: props.setNextDetailPhoto },
             toggleSelected: { combo: 'space', enabled: () => !!this.props.inSelectionMode, onAction: props.togglePhotoSelected },
             edit: { combo: 'enter', enabled: () => this.props.showEditButton, label: msg('PhotoDetailPane_edit'), onAction: props.enterCropMode },
+            delete: { combo: 'del', enabled: () => true, onAction: props.movePhotosToTrash },
         }
     }
 

--- a/src/app/ui/widget/PhotoActionButtons.tsx
+++ b/src/app/ui/widget/PhotoActionButtons.tsx
@@ -13,6 +13,7 @@ import { getCollectionSize } from 'app/util/PhotoCollectionResolver'
 
 import RotateButtonGroup from './RotateButtonGroup'
 
+import {movePhotosToTrash} from 'app/util/PhotoUtil'
 
 interface Props {
     selectedPhotos: PhotoCollection | null
@@ -51,15 +52,7 @@ export default class PhotoActionButtons extends React.Component<Props> {
 
     private moveToTrash() {
         const { props } = this
-        if (props.selectedPhotos) {
-            const photosCount = getCollectionSize(props.selectedPhotos)
-            props.photoActionController.movePhotosToTrash(props.selectedPhotos)
-            toaster.show({
-                icon: 'tick',
-                message: photosCount === 1 ? msg('PhotoActionButtons_movedToTrash_one') : msg('PhotoActionButtons_movedToTrash_more', formatNumber(photosCount)),
-                intent: 'success'
-            })
-        }
+        movePhotosToTrash(props.selectedPhotos, props.photoActionController)
     }
 
     private restoreFromTrash() {

--- a/src/app/util/PhotoUtil.ts
+++ b/src/app/util/PhotoUtil.ts
@@ -1,0 +1,18 @@
+import { getCollectionSize } from 'app/util/PhotoCollectionResolver'
+import { PhotoActionController } from 'app/controller/PhotoActionController'
+import { PhotoCollection } from 'app/state/StateTypes'
+import toaster from 'app/Toaster'
+import { msg } from 'common/i18n/i18n'
+import { formatNumber } from 'common/util/TextUtil'
+
+export function movePhotosToTrash(photos: PhotoCollection | null | undefined, controller: PhotoActionController) {
+    if (!photos) return
+    const photosCount = getCollectionSize(photos)
+    if (photosCount == 0) return
+    controller.movePhotosToTrash(photos)
+    toaster.show({
+        icon: 'tick',
+        message: photosCount === 1 ? msg('PhotoActionButtons_movedToTrash_one') : msg('PhotoActionButtons_movedToTrash_more', formatNumber(photosCount)),
+        intent: 'success'
+    })
+}


### PR DESCRIPTION
Support the "del" hotkey in photo detail view so that both browsing the photos and deleting the photos can be done with the keyboard only.